### PR TITLE
fixed dependency, as it does not install from pypi anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # dependencies
     install_requires=[
         'numpy>=1.17.2',
-        'sklearn',
+        'scikit_learn',
         'xgboost',
         'matplotlib',
         'pandas'


### PR DESCRIPTION
pip install sklearn does not work anymore from pypi as it has to be called scikit-learn now.

Installing the repo locally after cloning did still work.